### PR TITLE
TTSD-5985: add aws request signing snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # script-libraries
+
 JavaScript libraries compatible with the [Runscope API Test Script Engine](https://www.runscope.com/docs/api-testing/scripts).
 
-
-# Available libraries
+## Available libraries
 
 - [aws4](/aws4) ([Source](https://github.com/mhart/aws4)): Signs and prepares requests using AWS Signature Version 4.
 - [left-pad](/leftpad.js) ([Source](https://github.com/stevemao/left-pad)): The one, the only.
 - [URI.js](/uri.js) ([Source](https://medialize.github.io/URI.js)): URL parser. Includes IPv6, Punycode, SecondLevelDomains, and URITemplate add-ons.
 - [himalaya.js](/himalaya.js) ([Source](https://github.com/andrejewski/himalaya)): Parse HTML into JSON. Includes an example of how to use it in a post-response script. (thanks to [@NKjoep](https://github.com/NKjoep) for the PR!)
+
+## Snippets
+
+- [aws-request-signer](/snippets/aws-request-signer.js): Pre-request script for use with IAM authenticated requests
+
+To update these snippets
+
+- update the source code and make a PR in this repo
+- once the PR is merged, copy the file contents into the Runscope UI - [https://www.runscope.com/teams/3e6b1c72-9a3e-4c17-a05e-cfabdbf4d243/script-library](https://www.runscope.com/teams/3e6b1c72-9a3e-4c17-a05e-cfabdbf4d243/script-library)

--- a/snippets/aws-request-signer.js
+++ b/snippets/aws-request-signer.js
@@ -1,0 +1,38 @@
+// This script is used to sign the AWS request by the IAM role name provided. It is to be used in the Pre-request Scripts tab.
+// Prerequisites:
+// 1. Requires SIGv4 is Enabled For Environments via the aws4.js library
+//    More info here - https://ibotta.atlassian.net/wiki/spaces/TT/pages/3214376989/Runscope+-+SIGv4+Requests#Required-Role-Attachments
+// 2. This script requires you to define the following initial variable(s)
+//    - AWS_ROLE_NAME
+
+var awsRoleName = variables.get("AWS_ROLE_NAME");
+if (!awsRoleName) {
+  throw new Error("Missing required initial variable(s): AWS_ROLE_NAME");
+}
+
+var fullPath = request.path;
+if (request.method == "GET" && request.params.length > 0) {
+  var queryString = request.url.slice(request.url.indexOf("?"));
+  fullPath += queryString; //Re-add queryString with '?' to full path e.g. '?key1=val1&...'
+}
+
+var opts = {
+  host: request.host,
+  path: fullPath,
+  method: request.method,
+  body: request.body,
+  headers: request.headers,
+};
+
+var awsObj = aws4.sign(opts, {
+  accessKeyId: variables.get(awsRoleName + "_AKI"),
+  secretAccessKey: variables.get(awsRoleName + "_SAK"),
+  sessionToken: variables.get(awsRoleName + "_STKN"),
+});
+
+// Currently there is no need to re-update path, this causes issue for GET request with queryString. If this is needed for other request types, we can re-add it based on specific use case
+// request.path = awsObj.path;
+
+for (var header in awsObj.headers) {
+  request.headers[header] = awsObj.headers[header];
+}


### PR DESCRIPTION
Ticket - https://ibotta.atlassian.net/browse/TTSD-5985

This PR adds the reusable snippet into source control. Currently, it resides only within Runscope infrastructure.

This code was copied directly from the Runscope UI in the Script Library under the "AWS SIGv4 signing by IAM role" snippet.