### PR TITLE
TTSD-5985: add custom domain api gateways to request signing snippet

### DIFF
--- a/snippets/aws-request-signer.js
+++ b/snippets/aws-request-signer.js
@@ -24,6 +24,11 @@ var opts = {
   headers: request.headers,
 };
 
+// If not communicating directly with AWS service, we can assume a custom domain api gateway
+if (request.host.indexOf("amazonaws.com") < 0) {
+  opts.service = "execute-api";
+}
+
 var awsObj = aws4.sign(opts, {
   accessKeyId: variables.get(awsRoleName + "_AKI"),
   secretAccessKey: variables.get(awsRoleName + "_SAK"),


### PR DESCRIPTION
Ticket - https://ibotta.atlassian.net/browse/TTSD-5985

This PR is to enable custom domains for api gateways to have their requests signed properly. Currently, it's unable to pick up the appropriate AWS service to sign the request for.